### PR TITLE
Fix static asset routing to preserve websocket connections

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.websockets import WebSocketState
 
@@ -29,7 +30,11 @@ def create_app() -> FastAPI:
 
     static_dir = Path(__file__).resolve().parent.parent / "frontend"
     if static_dir.exists():
-        app.mount("/", StaticFiles(directory=str(static_dir), html=True), name="frontend")
+        app.mount("/static", StaticFiles(directory=str(static_dir)), name="frontend")
+
+        @app.get("/")
+        async def serve_index() -> FileResponse:
+            return FileResponse(static_dir / "index.html")
 
     synthesizer = SpeechSynthesizer()
     conversation_manager = ConversationManager()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Voice Conversation Demo</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
     <main class="container">
@@ -34,6 +34,6 @@
         </div>
       </section>
     </main>
-    <script type="module" src="app.js"></script>
+    <script type="module" src="/static/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- serve the SPA entrypoint with a dedicated FastAPI route so websocket handshakes bypass StaticFiles
- mount the frontend assets under /static and update HTML references accordingly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfaa902d388324bea7fe97d91cdddf